### PR TITLE
Adding the option to skip comment downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Run the script with `mitene_download https://mitene.us/f/abcd123456`, using the 
 This will download all photos and video in `out` folder. Some text files will be created with the comments.
 
 If the album is password-protected, you can specify the password using `--password` command line argument, similar to this: `mitene_download https://mitene.us/f/abcd123456 --password the_password`.
+
+To exclude comments (MD files) use the `--nocomments` command line argument, similar to this: `mitene_download https://mitene.us/f/abcd123456 --nocomments`

--- a/mitene_download.py
+++ b/mitene_download.py
@@ -63,7 +63,8 @@ async def async_main() -> None:
   parser.add_argument("--destination-directory", default="out")
   parser.add_argument("-p", "--password")
   parser.add_argument("-v", "--verbose", action="store_true")
-
+  parser.add_argument("--nocomments", action="store_true", help="Skip downloading comment files (.md).")
+  
   args = parser.parse_args()
 
   os.makedirs(args.destination_directory, exist_ok=True)
@@ -138,7 +139,7 @@ async def async_main() -> None:
           )
         )
 
-        if media["comments"]:
+        if not args.nocomments and media["comments"]:
           comment_text = "".join(
             f'**{comment["user"]["nickname"]}**: {comment["body"]}\n\n'
             for comment in media["comments"]


### PR DESCRIPTION
Thanks for creating/maintaining this. I figured this might be useful for others who might be backing up their photos and don't want to store or parse out the MD files.