### PR TITLE
Read password securely from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Run the script with `mitene_download https://mitene.us/f/abcd123456`, using the 
  
 This will download all photos and video in `out` folder. Some text files will be created with the comments.
 
-If the album is password-protected, you can specify the password using `--password` command line argument, similar to this: `mitene_download https://mitene.us/f/abcd123456 --password the_password`.
+If the album is password-protected, the script will prompt you to enter the password securely (input is hidden). You can also specify the password using `--password` command line argument, similar to this: `mitene_download https://mitene.us/f/abcd123456 --password the_password`; however this is unsafe and should be avoided, as the password may be visible in shell history, process lists, or logs.
 
 To exclude comments (MD files) use the `--nocomments` command line argument, similar to this: `mitene_download https://mitene.us/f/abcd123456 --nocomments`

--- a/mitene_download.py
+++ b/mitene_download.py
@@ -5,12 +5,12 @@ __version__ = "0.6.0"
 import argparse
 import asyncio
 import datetime
+import getpass
 import glob
 import json
 import mimetypes
 import os
 import pathlib
-import getpass
 import sys
 import urllib.parse
 from typing import Awaitable
@@ -92,7 +92,9 @@ async def async_main() -> None:
       if page == 1 and "Please enter your password" in response_text:
         if not args.password:
           try:
-            args.password = getpass.getpass("Album is password protected. Enter password: ")
+            args.password = getpass.getpass(
+              "Album is password protected. Enter password: "
+            )
           except (EOFError, KeyboardInterrupt):
             print(file=sys.stderr)
             print(

--- a/mitene_download.py
+++ b/mitene_download.py
@@ -10,6 +10,7 @@ import json
 import mimetypes
 import os
 import pathlib
+import getpass
 import sys
 import urllib.parse
 from typing import Awaitable
@@ -90,11 +91,18 @@ async def async_main() -> None:
       response_text = await r.text()
       if page == 1 and "Please enter your password" in response_text:
         if not args.password:
-          print(
-            "Album is password protected, please specify password with --password",
-            file=sys.stderr,
-          )
-          sys.exit(1)
+          try:
+            args.password = getpass.getpass("Album is password protected. Enter password: ")
+          except (EOFError, KeyboardInterrupt):
+            print(file=sys.stderr)
+            print(
+              "Cannot read password from terminal, please specify password with --password",
+              file=sys.stderr,
+            )
+            sys.exit(1)
+          if not args.password:
+            print("Password cannot be empty", file=sys.stderr)
+            sys.exit(1)
         authenticity_token = response_text.split('name="authenticity_token" value="')[
           1
         ].split('"')[0]


### PR DESCRIPTION
Thank you for creating mitene_download! I used it to back up our FamilyAlbum and found it very useful.

My only concern is that passing `--password` is not safe in many environments because command-line arguments can be exposed via process listings, shell history, logs, and CI output. 

With this change, when a password is required but `--password` is not provided, the script securely prompts using getpass so the input is hidden. It also handles Ctrl+C/Ctrl+D and empty passwords with clear error messages and exits cleanly.

The README file was updated to reflect the changes.