### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox and any other packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,9 +10,9 @@ jobs:
       runs-on: ubuntu-latest
   
       steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Install pypa/build
@@ -24,7 +24,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: python-package-distributions
           path: dist/
@@ -42,7 +42,7 @@ jobs:
         id-token: write
       steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v2/v4 → v5
- Update `actions/setup-python` v2/v4/v5 → v6
- Update `actions/upload-artifact` v4 → v6
- Update `actions/download-artifact` v4 → v6

Fixes Node.js 20 deprecation warnings. Node.js 20 actions will be forced to run on Node.js 24 starting June 2nd, 2026.

Made with [Cursor](https://cursor.com)